### PR TITLE
SQLAlchemy must be flushed to avoid running out of memory

### DIFF
--- a/socrata2sql/cli.py
+++ b/socrata2sql/cli.py
@@ -310,6 +310,7 @@ def main():
                     to_insert.append(Binding(**parse_row(row, Binding)))
 
                 session.add_all(to_insert)
+                session.flush()
                 bar.next(n=len(to_insert))
 
             bar.finish()


### PR DESCRIPTION
If we don't call flush, all of the changes will accumulate in memory and eventually exhaust the host's memory where socrata2sql is running. This does not mean that the transaction is committed, it just means that the rows are being written to the database and not queued in the tool.